### PR TITLE
Removed implemented-by flag from the responsibility assembly.

### DIFF
--- a/src/metaschema/oscal_responsibility-common_metaschema.xml
+++ b/src/metaschema/oscal_responsibility-common_metaschema.xml
@@ -176,7 +176,9 @@
         the document.</description>
     </define-flag>
     <flag ref="provided-uuid" required="no" />
+    <!-- Identifying the implementer of an inheritable control for which a responsibility exists can be done through provided-uuid.
     <flag ref="implemented-by" required="no" />
+    -->
     <flag ref="exportable" />
     <model>
       <define-field name="description" as-type="markup-multiline" min-occurs="1"


### PR DESCRIPTION
# Committer Notes

Updated the SSP and SR by removing `implemented-by` flag from the `responsibility` assembly, since the necessary information can be obtained by leveraging the traceability and traversing the document using `provided-uuid`.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

(For reviewers: [The wiki has guidance](https://github.com/usnistgov/OSCAL/wiki/Issue-Review) on code review and overall issue review for completeness.)

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
